### PR TITLE
Skip the test that tests the real atmo france pollutant source.

### DIFF
--- a/test/scenarios/pollutant/atmo-france/test-success.bats
+++ b/test/scenarios/pollutant/atmo-france/test-success.bats
@@ -65,6 +65,7 @@ load "../../../support/test-actions.bash"
 }
 
 @test "Test real atmo server pollutant data" {
+    skip "Data source currently down: https://www.data.gouv.fr/datasets/indice-de-la-qualite-de-lair-quotidien-par-commune-indice-atmo/#/discussions/68975f646683faf4c10d257f"
     # GIVEN a remote pollutant server running which returns valid data
     # AND a local pollutant server waiting for a request
     # WHEN a request is made to the local pollutant server


### PR DESCRIPTION
The data source is currently down: https://www.data.gouv.fr/datasets/indice-de-la-qualite-de-lair-quotidien-par-commune-indice-atmo/#/discussions/68975f646683faf4c10d257f

The tests which mock data are still working.